### PR TITLE
Fetch from project specified by `-p`

### DIFF
--- a/review.go
+++ b/review.go
@@ -109,7 +109,8 @@ func makeReviewTemplate(ctx context.Context, n int) string {
 	}()
 	go func() {
 		start := time.Now()
-		cmd := exec.Command("git", "fetch", "-f", "https://github.com/cockroachdb/cockroach", "master", fmt.Sprintf("refs/pull/%d/head:refs/reviews/%d", n, n))
+		repoURL := fmt.Sprintf("https://github.com/%s/%s", projectOwner, projectRepo)
+		cmd := exec.Command("git", "fetch", "-f", repoURL, "master", fmt.Sprintf("refs/pull/%d/head:refs/reviews/%d", n, n))
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Fixes #1.

Small change to `makeReviewTemplate` so it uses the values passed via
`-p`.  This makes it so `re` can review PRs to any Github repo, e.g.,

    $ re -p rmloveland/github-scripts 1