### PR TITLE
Back up in-progress comments file to *.bak

### DIFF
--- a/review.go
+++ b/review.go
@@ -364,6 +364,13 @@ func review(prNum int, filename string) *github.PullRequestReviewRequest {
 	stdin := bufio.NewReader(os.Stdin)
 	editReview := true
 	var request *github.PullRequestReviewRequest
+
+	backupReviewCmd := exec.Command("cp", filename, fmt.Sprintf("%s.bak", filename))
+	err := backupReviewCmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	for {
 		if editReview {
 			request = parseFileUntilSuccess(filename)


### PR DESCRIPTION
This change does the dumbest thing possible: make a backup of the review file with a .bak extension before attempting to push it back up to Github.

This addresses the main concern expressed in #10, which is that under the current behavior if the API call to Github fails, the temp file *still gets deleted*, and you can lose a lot of work.