### PR TITLE
Back up review file before upload

### DIFF
--- a/review.go
+++ b/review.go
@@ -377,6 +377,7 @@ func review(prNum int, filename string) *github.PullRequestReviewRequest {
 		} else if err == io.EOF {
 			exitHappy()
 		}
+		backupReview(filename)
 		switch text[0] {
 		case 'y':
 			request.Event = &reviewComment
@@ -422,6 +423,14 @@ func review(prNum int, filename string) *github.PullRequestReviewRequest {
 			color.Unset()
 			continue
 		}
+	}
+}
+
+func backupReview(filename string) {
+	backupReviewCmd := exec.Command("cp", filename, fmt.Sprintf("%s.bak", filename))
+	err := backupReviewCmd.Run()
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This change does the dumbest thing possible: make a backup of the review
file with a .bak extension before attempting to push it back up to
Github.

This addresses the main concern expressed in #10, which is that under
the current behavior if the API call to Github fails, the temp
file *still gets deleted*, and you can lose a lot of work.